### PR TITLE
Get email address from x-amzn-oidc-data header

### DIFF
--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -203,6 +203,8 @@ var Config = struct {
 	// Identify users through headers
 	HeaderAuthEnabled   bool   `env:"FLAGR_HEADER_AUTH_ENABLED" envDefault:"false"`
 	HeaderAuthUserField string `env:"FLAGR_HEADER_AUTH_USER_FIELD" envDefault:"X-Email"`
+	// For those situations where ALB is in front of Flagr. Enabling this will parse x-amzn-oidc-data header.
+	HeaderAuthUserFieldAwsAlb bool `env:"FLAGR_HEADER_AUTH_USER_FIELD_AWS_ALB" envDefault:"false"`
 
 	// Authenticate with basic auth
 	BasicAuthEnabled              bool     `env:"FLAGR_BASIC_AUTH_ENABLED" envDefault:"false"`

--- a/pkg/handler/subject.go
+++ b/pkg/handler/subject.go
@@ -1,7 +1,11 @@
 package handler
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/openflagr/flagr/pkg/config"
 	"github.com/openflagr/flagr/pkg/util"
@@ -25,7 +29,27 @@ func getSubjectFromRequest(r *http.Request) string {
 		}
 
 	} else if config.Config.HeaderAuthEnabled {
-		return r.Header.Get(config.Config.HeaderAuthUserField)
+		// https://docs.aws.amazon.com/elasticloadbalancing/latest/application/listener-authenticate-users.html
+		if config.Config.HeaderAuthUserFieldAwsAlb {
+			encodedJwt := r.Header.Get("x-amzn-oidc-data")
+			jwtPayload := strings.Split(encodedJwt, ".")[1]
+			rawData, err := base64.StdEncoding.DecodeString(jwtPayload)
+			if err != nil {
+				fmt.Println("Error decoding base64 x-amzn-oidc-data header:", err)
+				return ""
+			}
+
+			var jsonMap map[string]interface{}
+			err = json.Unmarshal(rawData, &jsonMap)
+			if err != nil {
+				fmt.Println("Error unmarshaling JSON:", err)
+				return ""
+			}
+
+			return jsonMap["email"].(string)
+		} else {
+			return r.Header.Get(config.Config.HeaderAuthUserField)
+		}
 	}
 
 	return ""


### PR DESCRIPTION
When using AWS ALB in front of Flagr, we need a way to get the user info to show in the UI who made changes to a flag. There is no built-in capability for that so this commit adds it.

If `FLAGR_HEADER_AUTH_USER_FIELD_AWS_ALB` is `true`, we look up the value of `x-amzn-oidc-data` header which contains 3 base64 encoded strings separated by dots (`.`). The element at index 1 contains the data we need:
```
{"sub":"00ulryc43ftxDjmqZ0x7","name":"Fardin Khanjani","locale":"DK","email":"fardin.khanjani@tradeshift.com","preferred_username":"fardin.khanjani@tradeshift.com","given_name":"Fardin","family_name":"Khanjani","zoneinfo":"America/Los_Angeles","updated_at":1683740733,"email_verified":true,"exp":1688549942,"iss":"https://tradeshift.okta.com"}
```

we then return the value of `email` attribute.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.